### PR TITLE
Fix gesture issue

### DIFF
--- a/Rideau/RideauViewDragGestureRecognizer.swift
+++ b/Rideau/RideauViewDragGestureRecognizer.swift
@@ -37,10 +37,16 @@ final class RideauViewDragGestureRecognizer: UIPanGestureRecognizer {
     trackingScrollView = event.findVerticalScrollView()
     super.touchesBegan(touches, with: event)
   }
-
+  
   override func touchesMoved(_ touches: Set<UITouch>, with event: UIEvent) {
-
     super.touchesMoved(touches, with: event)
+    
+    if state == .began {
+      let vel = velocity(in: view)
+      if abs(vel.x) > abs(vel.y) {
+        state = .cancelled
+      }
+    }
   }
 
   override func touchesEnded(_ touches: Set<UITouch>, with event: UIEvent) {


### PR DESCRIPTION
First of all, thank you for providing the awesome library.

Due to the Rideau structure, there is no need to control the horizontal gesture and it interferes with other gestures, so it is changed to cancel when recognized.